### PR TITLE
Label Operation

### DIFF
--- a/src/main/java/com/certusoft/zjsonpatch/DiffFlags.java
+++ b/src/main/java/com/certusoft/zjsonpatch/DiffFlags.java
@@ -29,12 +29,20 @@ public enum DiffFlags {
 
     /**
      * This flag adds a <i>fromValue</i> field to all {@link Operation#REPLACE}operations.
-     * <i>fromValue</i> represents the the value replaced by a {@link Operation#REPLACE}
+     * <i>fromValue</i> represents the value replaced by a {@link Operation#REPLACE}
      * operation, in other words, the original value.
      *
      * @since 0.4.1
      */
-    ADD_ORIGINAL_VALUE_ON_REPLACE;
+    ADD_ORIGINAL_VALUE_ON_REPLACE,
+
+    /**
+     * This flag adds a {@link Operation#LABEL}operation when a {@link Operation#REPLACE} occurs.
+     * This value represents name of the object changed by the {@link Operation#REPLACE}
+     * operation. This is useful for displaying diff data.
+     *
+     */
+    INCLUDE_LABELS_OPERATION;
 
 
     public static EnumSet<DiffFlags> defaults() {

--- a/src/main/java/com/certusoft/zjsonpatch/JsonDiffTyped.java
+++ b/src/main/java/com/certusoft/zjsonpatch/JsonDiffTyped.java
@@ -43,7 +43,7 @@ public final class JsonDiffTyped extends JsonDiff {
     }
 
     @Override
-    protected void generateDiffs(List<Diff> diffs, List<Object> path, JsonNode source, JsonNode target) {
+    protected boolean generateDiffs(List<Diff> diffs, List<Object> path, JsonNode source, JsonNode target) {
         if (!source.equals(target)) {
             NodeType sourceType = NodeType.getNodeType(source);
             NodeType targetType = NodeType.getNodeType(target);
@@ -55,11 +55,13 @@ public final class JsonDiffTyped extends JsonDiff {
                 if (source.decimalValue().subtract(target.decimalValue()).abs().compareTo(epsilon) > 0) {
                     // If the difference between the BigDecimal values is > EPSILON count as a difference
                     diffs.add(Diff.generateDiff(Operation.REPLACE, path, source, target));
+                    return true;
                 }
             } else {
                 diffs.add(Diff.generateDiff(Operation.REPLACE, path, source, target));
+                return true;
             }
         }
-
+        return false;
     }
 }

--- a/src/main/java/com/certusoft/zjsonpatch/Operation.java
+++ b/src/main/java/com/certusoft/zjsonpatch/Operation.java
@@ -30,6 +30,7 @@ enum Operation {
     REPLACE("replace"),
     MOVE("move"),
     COPY("copy"),
+    LABEL("label"),
     TEST("test");
 
     private final static Map<String, Operation> OPS = createImmutableMap();
@@ -41,6 +42,7 @@ enum Operation {
         map.put(REPLACE.rfcName, REPLACE);
         map.put(MOVE.rfcName, MOVE);
         map.put(COPY.rfcName, COPY);
+        map.put(LABEL.rfcName, LABEL);
         map.put(TEST.rfcName, TEST);
         return Collections.unmodifiableMap(map);
     }


### PR DESCRIPTION
Add a 'LABEL' operation type. This operation adds a "name" field to the diff when there are changes to an object node. This operation is used internally, and in the actual output is represented as a no-op 'REPLACE' operation with the same values for 'value' and 'fromValue' for a "name" field (And thus should still produce a valid 'RFC 6902 JSON Patch'. A flag has been added to toggle this feature: 'INCLUDE_LABELS_OPERATION'. This is useful for improving readability when displaying diff info.