### PR TITLE
Add an 'Unimportant' flag to diff entries. This flag indicates that t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>2.3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.6.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/src/main/java/com/certusoft/zjsonpatch/Constants.java
+++ b/src/main/java/com/certusoft/zjsonpatch/Constants.java
@@ -22,12 +22,13 @@ package com.certusoft.zjsonpatch;
  * Date: 10/07/15
  * Time: 10:35 AM
  */
-final class Constants {
+public final class Constants {
     public static final String OP = "op";
     public static final String VALUE = "value";
     public static final String PATH = "path";
     public static final String FROM = "from";
     public static final String FROM_VALUE = "fromValue";
+    public static final String UNIMPORTANT = "unimportant";
 
     private Constants() {}
 

--- a/src/main/java/com/certusoft/zjsonpatch/DiffFlags.java
+++ b/src/main/java/com/certusoft/zjsonpatch/DiffFlags.java
@@ -28,7 +28,7 @@ public enum DiffFlags {
     OMIT_COPY_OPERATION,
 
     /**
-     * This flag adds a <i>fromValue</i> field to all {@link Operation#REPLACE}operations.
+     * This flag adds a <i>fromValue</i> field to all {@link Operation#REPLACE} operations.
      * <i>fromValue</i> represents the value replaced by a {@link Operation#REPLACE}
      * operation, in other words, the original value.
      *
@@ -42,7 +42,15 @@ public enum DiffFlags {
      * operation. This is useful for displaying diff data.
      *
      */
-    INCLUDE_LABELS_OPERATION;
+    INCLUDE_LABELS_OPERATION,
+
+    /**
+     * This flag adds an <i>unimportant</i> flag to all {@link Operation#REPLACE} operations.
+     * <i>unimportant</i> indicates the value changed by a {@link Operation#REPLACE}
+     * operation was deemed unimportant by the supplied Regular Expressions.
+     *
+     */
+    INCLUDE_UNIMPORTANT_CHANGES;
 
 
     public static EnumSet<DiffFlags> defaults() {

--- a/src/main/java/com/certusoft/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/certusoft/zjsonpatch/JsonDiff.java
@@ -36,11 +36,11 @@ public class JsonDiff {
     }
 
     public JsonNode asJson(final JsonNode source, final JsonNode target) {
-        return asJson(source, target, DiffFlags.defaults(), new ArrayList<>());
+        return asJson(source, target, DiffFlags.defaults(), new ArrayList<String>());
     }
 
     public JsonNode asJson(final JsonNode source, final JsonNode target, EnumSet<DiffFlags> flags) {
-        return asJson(source, target, flags, new ArrayList<>());
+        return asJson(source, target, flags, new ArrayList<String>());
     }
 
     public JsonNode asJson(final JsonNode source, final JsonNode target, List<String> unimportantPatterns) {
@@ -48,8 +48,8 @@ public class JsonDiff {
     }
 
     public JsonNode asJson(final JsonNode source, final JsonNode target, EnumSet<DiffFlags> flags, List<String> unimportantPatterns) {
-        final List<Diff> diffs = new ArrayList<>();
-        List<Object> path = new ArrayList<>(0);
+        final List<Diff> diffs = new ArrayList<Diff>();
+        List<Object> path = new ArrayList<Object>(0);
 
         // generating diffs in the order of their occurrence
 
@@ -141,8 +141,8 @@ public class JsonDiff {
     }
 
     private Map<JsonNode, List<Object>> getUnchangedPart(JsonNode source, JsonNode target) {
-        Map<JsonNode, List<Object>> unchangedValues = new HashMap<>();
-        computeUnchangedValues(unchangedValues, new ArrayList<>(), source, target);
+        Map<JsonNode, List<Object>> unchangedValues = new HashMap<JsonNode, List<Object>>();
+        computeUnchangedValues(unchangedValues, new ArrayList<Object>(), source, target);
         return unchangedValues;
     }
 
@@ -234,7 +234,7 @@ public class JsonDiff {
     //Note : only to be used for arrays
     //Finds the longest common Ancestor ending at Array
     private void computeRelativePath(List<Object> path, int startIdx, int endIdx, List<Diff> diffs) {
-        List<Integer> counters = new ArrayList<>(path.size());
+        List<Integer> counters = new ArrayList<Integer>(path.size());
 
         resetCounters(counters, path.size());
 
@@ -334,9 +334,12 @@ public class JsonDiff {
                 }
                 if (diff.getOperation().equals(Operation.REPLACE) && // This process is unique to REPLACE, and shouldn't fall through for LABEL
                         flags.contains(DiffFlags.INCLUDE_UNIMPORTANT_CHANGES)) {
-                    if (unimportantPatterns.stream()
-                            .anyMatch(pattern -> diff.getSrcValue().asText().matches(pattern) &&
-                                    diff.getValue().asText().matches(pattern))) { // Check regular expressions
+                    // Check regular expressions
+                    boolean matches = false;
+                    for (String pattern : unimportantPatterns) {
+                        matches |= (diff.getSrcValue().asText().matches(pattern) && diff.getValue().asText().matches(pattern));
+                    }
+                    if (matches) {
                         jsonNode.put(Constants.UNIMPORTANT, true);
                     } else {
                         jsonNode.put(Constants.UNIMPORTANT, false);
@@ -474,7 +477,7 @@ public class JsonDiff {
             JsonNode srcName = source.get("name");
             JsonNode tarName = target.get("name");
             if (srcName != null && !srcName.asText().equals("") && tarName != null && !tarName.asText().equals("")) {
-                List<Object> namePath = new ArrayList<>(path.size() + 1);
+                List<Object> namePath = new ArrayList<Object>(path.size() + 1);
                 namePath.addAll(path);
                 namePath.add("name");
                 Diff tmpDiff = Diff.generateDiff(Operation.LABEL, namePath, srcName, tarName);
@@ -494,7 +497,7 @@ public class JsonDiff {
     }
 
     private List<Object> getPath(List<Object> path, Object key) {
-        List<Object> toReturn = new ArrayList<>(path.size() + 1);
+        List<Object> toReturn = new ArrayList<Object>(path.size() + 1);
         toReturn.addAll(path);
         toReturn.add(key);
         return toReturn;

--- a/src/main/java/com/certusoft/zjsonpatch/Operation.java
+++ b/src/main/java/com/certusoft/zjsonpatch/Operation.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * User: gopi.vishwakarma
  * Date: 30/07/14
  */
-enum Operation {
+public enum Operation {
     ADD("add"),
     REMOVE("remove"),
     REPLACE("replace"),


### PR DESCRIPTION
…he change has been determined to be unimportant. This happens when a REPLACE operation occurs, and both the 'value' and 'fromValue' fields match a provided regular expression. This is useful for marking fields like 'lastUpdate' unimportant by matching a date structure.